### PR TITLE
Allow body to be of type FormData for File Upload

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -17,7 +17,7 @@ export type RequestHandler = (url: string, requestProperties?: RequestInit) => P
 
 const getHeaders = (requestProperties: RequestInit): HeadersInit => {
     const headers = requestProperties.headers || {};
-    if ('body' in requestProperties) {
+    if ('body' in requestProperties && !(requestProperties.body instanceof FormData)) {
         if (headers instanceof Headers) {
             headers.set('Content-Type', 'application/json');
         } else if (Array.isArray(headers)) {
@@ -43,7 +43,7 @@ const defaultRequestHandler: RequestHandler = ((url, requestProperties = {}) => 
         console.log('Executing request: ' + url);
     }
     requestProperties.headers = getHeaders(requestProperties);
-    if (typeof requestProperties.body !== 'string') {
+    if (typeof requestProperties.body !== 'string' && !(requestProperties.body instanceof FormData)) {
         requestProperties.body = JSON.stringify(requestProperties.body);
     }
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Allow body to be of type FormData, without it setting header to json. This allows a file upload through a FormData body.

Sample formData:

`let formDataToUpload = new FormData();`
`formDataToUpload.append("otherPostVariable", "value");`
`formDataToUpload.append('myFile', {`
`    uri : fileData.uri,`
`    type: fileData.contentType,`
`    name: fileData.name`
`});`

Dit kun je meegeven als body aan de performApiRequest.