### PR TITLE
Fas-252 api data actions

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,40 +1,39 @@
 # API
   ## Table of Contents
-- [API](#api)
-  - [Table of Contents](#table-of-contents)
-  - [HOC](#hoc)
-    - [`withApiData()`](#withapidata)
-  - [Config](#config)
-    - [`configureApiData()`](#configureapidata)
-    - [`useRequestHandler()`](#userequesthandler)
-  - [Redux Actions](#redux-actions)
-    - [`afterRehydrate()`](#afterrehydrate)
-    - [`performApiRequest()` (Deprecated)](#performapirequest-deprecated)
-    - [`invalidateApiDataRequest()` (Deprecated)](#invalidateapidatarequest-deprecated)
-  - [Selectors](#selectors)
-    - [`getEntity()`](#getentity)
-    - [`getApiDataRequest()` (Deprecated)](#getapidatarequest-deprecated)
-    - [`getResultData()` (Deprecated)](#getresultdata-deprecated)
-  - [Types and interfaces](#types-and-interfaces)
-    - [`NetworkStatus`](#networkstatus)
-    - [`ApiDataBinding`](#apidatabinding)
-    - [`Actions`](#actions)
-    - [`ApiDataRequest`](#apidatarequest)
-    - [`EndpointParams`](#endpointparams)
-    - [`ApiDataEndpointConfig`](#apidataendpointconfig)
-    - [`ApiDataGlobalConfig`](#apidataglobalconfig)
-    - [`ApiDataConfigBeforeProps`](#apidataconfigbeforeprops)
-    - [`ApiDataConfigAfterProps`](#apidataconfigafterprops)
-    - [`ApiDataState`](#apidatastate)
-    - [`RequestHandler`](#requesthandler)
-    - [`HandledResponse`](#handledresponse)
+  
+- [HOC](#hoc)
+  - [`withApiData()`](#withapidata)
+- [Config](#config)
+  - [`configureApiData()`](#configureapidata)
+  - [`useRequestHandler()`](#userequesthandler)
+- [Redux Actions](#redux-actions)
+  - [`afterRehydrate()`](#afterrehydrate)
+  - [`performApiRequest()` (Deprecated)](#performapirequest-deprecated)
+  - [`invalidateApiDataRequest()` (Deprecated)](#invalidateapidatarequest-deprecated)
+- [Selectors](#selectors)
+  - [`getEntity()`](#getentity)
+  - [`getApiDataRequest()` (Deprecated)](#getapidatarequest-deprecated)
+  - [`getResultData()` (Deprecated)](#getresultdata-deprecated)
+- [Types and interfaces](#types-and-interfaces)
+  - [`NetworkStatus`](#networkstatus)
+  - [`ApiDataBinding`](#apidatabinding)
+  - [`Actions`](#actions)
+  - [`ApiDataRequest`](#apidatarequest)
+  - [`EndpointParams`](#endpointparams)
+  - [`ApiDataEndpointConfig`](#apidataendpointconfig)
+  - [`ApiDataGlobalConfig`](#apidataglobalconfig)
+  - [`ApiDataConfigBeforeProps`](#apidataconfigbeforeprops)
+  - [`ApiDataConfigAfterProps`](#apidataconfigafterprops)
+  - [`ApiDataState`](#apidatastate)
+  - [`RequestHandler`](#requesthandler)
+  - [`HandledResponse`](#handledresponse)
 
 ## HOC
 
 ### `withApiData()`
 
 Binds api data to component props and automatically triggers loading of data if it hasn't been loaded yet. The wrapped
-component will get an [ApiDataBinding](#apidatabinding) or [ApiDataBinding](#apidatabinding)[] added to each property key of the bindings param.
+component will get an [ApiDataBinding](#apidatabinding) or [ApiDataBinding](#apidatabinding)[] added to each property key of the bindings param and a property `apiDataActions` of type [Action](#action).
 
 **Parameters**
 
@@ -43,7 +42,7 @@ component will get an [ApiDataBinding](#apidatabinding) or [ApiDataBinding](#api
 
 **Returns**
 
-**Function** Function to wrap your component, which adds a prop for each binding and an apiDataActions prop with type [Actions](#actions).
+**Function** Function to wrap your component. This higher order component adds a property for each binding, as defined in the bindings param of the HOC, to the wrapped component and an additional apiDataActions property with type [Actions](#actions).
 
 **Examples**
  ```javascript
@@ -60,10 +59,11 @@ withApiData({
         userId: user.id
     })),
     editArticle: {}
-}));
+}))(MyComponent);
 // props.article will be an ApiDataBinding
 // props.users will be an array of ApiDataBinding
 // props.editArticle will be an ApiDataBinding
+// props.apiDataActions will be an Actions object
 
 // perform can be used to trigger calls with autoTrigger: false
 props.editArticle.perform({
@@ -72,6 +72,9 @@ props.editArticle.perform({
     title: 'New Title',
     content: 'New article content'
 });
+
+// the apiDataAction property can be used to perform actions on any endpoint in the endpoint config, not only those which are in the current binding.
+props.apiDataActions.invalidateCache('getArticles');
 ```
 
 
@@ -127,8 +130,8 @@ The performApiRequest Action has been deprecated. It is recommended to use the p
 **Parameters**
 
 - `endpointKey` **string**
-- `params` **[EndpointParams](#endpointparams)**
-- `body` **any**
+- `params?` **[EndpointParams](#endpointparams)**
+- `body?` **any**
 - `instanceId?` **string**
 
 **Returns**
@@ -149,7 +152,7 @@ The invalidateApiDataRequest Action has been deprecated. It is recommended to us
 **Parameters**
 
 - `endpointKey` **string**
-- `params` **[EndpointParams](#endpointparams)**
+- `params?` **[EndpointParams](#endpointparams)**
 - `instanceId?` **string**
 
 **Returns**
@@ -266,8 +269,8 @@ Perform actions on any configured endpoint. These actions do not need to be disp
 
 **Properties**
 
-- `perform` **(`endpointKey` string, `params` [EndpointParams](#endpointparams), `body` any, `instanceId?` string) => [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>** Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For GET requests it is preferred to use [withApiData](#withapidata).
-- `invalidateCache` **(`endpointKey` string, `params` [EndpointParams](#endpointparams), `instanceId?` string) => void** Invalidates the result of a request, settings it's status back to 'ready'. Use for example after a POST, to invalidate
+- `perform` **(`endpointKey` string, `params?` [EndpointParams](#endpointparams), `body?` any, `instanceId?` string) => [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>** Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For GET requests it is preferred to use [withApiData](#withapidata).
+- `invalidateCache` **(`endpointKey` string, `params?` [EndpointParams](#endpointparams), `instanceId?` string) => void** Invalidates the result of a request, settings it's status back to 'ready'. Use for example after a POST, to invalidate
 a GET list request, which might need to include the newly created entity.
 
 ---

--- a/api.md
+++ b/api.md
@@ -8,13 +8,13 @@
     - [`configureApiData()`](#configureapidata)
     - [`useRequestHandler()`](#userequesthandler)
   - [Actions](#actions)
+    - [`afterRehydrate()`](#afterrehydrate)
     - [`performApiRequest()` (Deprecated)](#performapirequest-deprecated)
     - [`invalidateApiDataRequest()` (Deprecated)](#invalidateapidatarequest-deprecated)
-    - [`afterRehydrate()`](#afterrehydrate)
   - [Selectors](#selectors)
-    - [getApiDataRequest()](#getapidatarequest)
-    - [getResultData()](#getresultdata)
     - [getEntity()](#getentity)
+    - [`getApiDataRequest()` (Deprecated)](#getapidatarequest-deprecated)
+    - [`getResultData()` (Deprecated)](#getresultdata-deprecated)
   - [Types and interfaces](#types-and-interfaces)
     - [`NetworkStatus`](#networkstatus)
     - [`ApiDataBinding`](#apidatabinding)
@@ -104,6 +104,17 @@ Use your own request function that calls the api and reads the responseBody resp
 
 ## Actions
 
+### `afterRehydrate()`
+
+Call this after you've re-hydrated the store when using redux-persist or any other method of persisting and restoring
+the entire apiData state. This is needed to reset loading statuses.
+
+**Returns**
+
+**Object** Redux action to dispatch
+
+---
+
 ### `performApiRequest()` (Deprecated)
 
 Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For GET requests it is preferred
@@ -145,57 +156,7 @@ The invalidateApiDataRequest Action has been deprecated. It is recommended to us
 
 **Object** Redux action to dispatch
 
----
-
-### `afterRehydrate()`
-
-Call this after you've re-hydrated the store when using redux-persist or any other method of persisting and restoring
-the entire apiData state. This is needed to reset loading statuses.
-
-**Returns**
-
-**Object** Redux action to dispatch
-
-
 ## Selectors
-
-### getApiDataRequest()
-
-Selector to manually get a [ApiDataRequest](#apidatarequest). This value is automatically bind when using [withApiData](#withapidata).
-This selector can be useful for tracking request status when a request is triggered manually, like a POST after a
-button click.
-
-**Parameters**
-
-- `apiDataState` **[ApiDataState](#apidatastate)**
-- `endpointKey` **string**
-- `params` **[EndpointParams](#endpointparams)**
-- `instanceId?` **string**
-
-**Returns**
-
-**[ApiDataRequest](#apidatarequest) | void**
-
----
-
-### getResultData()
-
-Get the de-normalized result data of an endpoint, or undefined if not (yet) available. This value is automatically
-bound when using [withApiData](#withapidata). This selector can be useful for getting response responseBody values when a request is
-triggered manually, like a POST after a button click.
-
-**Parameters**
-
-- `apiDataState` **[ApiDataState](#apidatastate)**
-- `endpointKey` **string**
-- `params` **[EndpointParams](#endpointparams)**
-- `instanceId?` **string**
-
-**Returns**
-
-**any**
-
----
 
 ### getEntity()
 
@@ -210,6 +171,52 @@ Selector for getting a single entity from normalized data.
 **Returns**
 
 **Object | void**
+
+---
+
+### `getApiDataRequest()` (Deprecated)
+
+Selector to manually get a [ApiDataRequest](#apidatarequest). This value is automatically bind when using [withApiData](#withapidata).
+This selector can be useful for tracking request status when a request is triggered manually, like a POST after a
+button click.
+
+**Deprecated**
+
+The getApiDataRequest selector has been deprecated. It is recommended to use the request property returned by the [ApiDataBinding](#apidatabinding), which is returned by the [HOC](#withapidata).
+
+**Parameters**
+
+- `apiDataState` **[ApiDataState](#apidatastate)**
+- `endpointKey` **string**
+- `params` **[EndpointParams](#endpointparams)**
+- `instanceId?` **string**
+
+**Returns**
+
+**[ApiDataRequest](#apidatarequest) | void**
+
+---
+
+### `getResultData()` (Deprecated)
+
+Get the de-normalized result data of an endpoint, or undefined if not (yet) available. This value is automatically
+bound when using [withApiData](#withapidata). This selector can be useful for getting response responseBody values when a request is
+triggered manually, like a POST after a button click.
+
+**Deprecated**
+
+The getResultData selector has been deprecated. It is recommended to use the request property returned by the [ApiDataBinding](#apidatabinding), which is returned by the [HOC](#withapidata).
+
+**Parameters**
+
+- `apiDataState` **[ApiDataState](#apidatastate)**
+- `endpointKey` **string**
+- `params` **[EndpointParams](#endpointparams)**
+- `instanceId?` **string**
+
+**Returns**
+
+**any**
 
 
 ## Types and interfaces

--- a/api.md
+++ b/api.md
@@ -111,7 +111,7 @@ to use [withApiData](#withapidata).
 
 **Deprecated**
 
-The performApiRequest Action has been deprecated. It is recommended to use the [ApiDataAction](#apidataaction) perform, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
+The performApiRequest Action has been deprecated. It is recommended to use the perform action in the [ApiDataBinding](#apidatabinding) or the [ApiDataAction](#apidataaction) perform, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
 
 **Parameters**
 
@@ -133,7 +133,7 @@ a GET list request, which might need to include the newly created entity.
 
 **Deprecated**
 
-The invalidateApiDataRequest Action has been deprecated. It is recommended to use the [ApiDataAction](#apidataaction) invalidateCache, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
+The invalidateApiDataRequest Action has been deprecated. It is recommended to use the invalidateCache action in the [ApiDataBinding](#apidatabinding) or the [ApiDataAction](#apidataaction) invalidateCache, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
 
 **Parameters**
 

--- a/api.md
+++ b/api.md
@@ -1,30 +1,33 @@
 # API
   ## Table of Contents
-- [HOC](#hoc)
-  - [`withApiData()`](#withapidata)
-- [Config](#config)
-  - [`configureApiData()`](#configureapidata)
-  - [`useRequestHandler()`](#userequesthandler)
-- [Actions](#actions)
-  - [`performApiRequest()`](#performapirequest)
-  - [`invalidateApiDataRequest()`](#invalidateapidatarequest)
-  - [`afterRehydrate()`](#afterrehydrate)
-- [Selectors](#selectors)
-  - [`getApiDataRequest()`](#getapidatarequest)
-  - [`getResultData()`](#getresultdata)
-  - [`getEntity()`](#getentity)
-- [Types and interfaces](#types-and-interfaces)
-  - [`NetworkStatus`](#networkstatus)
-  - [`ApiDataBinding`](#apidatabinding)
-  - [`ApiDataRequest`](#apidatarequest)
-  - [`EndpointParams`](#endpointparams)
-  - [`ApiDataEndpointConfig`](#apidataendpointconfig)
-  - [`ApiDataGlobalConfig`](#apidataglobalconfig)
-  - [`ApiDataConfigBeforeProps`](#apidataconfigbeforeprops)
-  - [`ApiDataConfigAfterProps`](#apidataconfigafterprops)
-  - [`ApiDataState`](#apidatastate)
-  - [`RequestHandler`](#requesthandler)
-  - [`HandledResponse`](#handledresponse)
+- [API](#api)
+  - [Table of Contents](#table-of-contents)
+  - [HOC](#hoc)
+    - [`withApiData()`](#withapidata)
+  - [Config](#config)
+    - [`configureApiData()`](#configureapidata)
+    - [`useRequestHandler()`](#userequesthandler)
+  - [Actions](#actions)
+    - [`performApiRequest()` (Deprecated)](#performapirequest-deprecated)
+    - [`invalidateApiDataRequest()` (Deprecated)](#invalidateapidatarequest-deprecated)
+    - [`afterRehydrate()`](#afterrehydrate)
+  - [Selectors](#selectors)
+    - [getApiDataRequest()](#getapidatarequest)
+    - [getResultData()](#getresultdata)
+    - [getEntity()](#getentity)
+  - [Types and interfaces](#types-and-interfaces)
+    - [`NetworkStatus`](#networkstatus)
+    - [`ApiDataBinding`](#apidatabinding)
+    - [`Actions`](#actions)
+    - [`ApiDataRequest`](#apidatarequest)
+    - [`EndpointParams`](#endpointparams)
+    - [`ApiDataEndpointConfig`](#apidataendpointconfig)
+    - [`ApiDataGlobalConfig`](#apidataglobalconfig)
+    - [`ApiDataConfigBeforeProps`](#apidataconfigbeforeprops)
+    - [`ApiDataConfigAfterProps`](#apidataconfigafterprops)
+    - [`ApiDataState`](#apidatastate)
+    - [`RequestHandler`](#requesthandler)
+    - [`HandledResponse`](#handledresponse)
 
 ## HOC
 
@@ -40,7 +43,7 @@ component will get an [ApiDataBinding](#apidatabinding) or [ApiDataBinding](#api
 
 **Returns**
 
-**Function** Function to wrap your component
+**Function** Function to wrap your component, which adds a prop for each binding and an apiDataActions prop with type [Actions](#actions).
 
 **Examples**
  ```javascript
@@ -101,10 +104,14 @@ Use your own request function that calls the api and reads the responseBody resp
 
 ## Actions
 
-### `performApiRequest()`
+### `performApiRequest()` (Deprecated)
 
-Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For get requests it is preferred
+Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For GET requests it is preferred
 to use [withApiData](#withapidata).
+
+**Deprecated**
+
+The performApiRequest Action has been deprecated. It is recommended to use the [ApiDataAction](#apidataaction) perform, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
 
 **Parameters**
 
@@ -115,14 +122,18 @@ to use [withApiData](#withapidata).
 
 **Returns**
 
-**Object** Redux action to dispatch. Dispatching this returns: **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>** Rejects when endpointKey is unkown. Otherwise resolves with ApiDataBinding after call has completed. Use request networkStatus to see if call was succeeded or not.
+**Object** Redux action to dispatch. Dispatching this returns: **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>** Rejects when endpointKey is unknown. Otherwise resolves with ApiDataBinding after call has completed. Use request networkStatus to see if call was succeeded or not.
 
 ---
 
-### `invalidateApiDataRequest()`
+### `invalidateApiDataRequest()` (Deprecated)
 
 Invalidates the result of a request, settings it's status back to 'ready'. Use for example after a POST, to invalidate
 a GET list request, which might need to include the newly created entity.
+
+**Deprecated**
+
+The invalidateApiDataRequest Action has been deprecated. It is recommended to use the [ApiDataAction](#apidataaction) invalidateCache, which is returned by the [HOC](#withapidata) in the apiDataActions prop, and in the [afterSuccess](#ApiDataEndpointConfig) and [afterFailed](#ApiDataEndpointConfig) events in the [endpoint configuration](##ApiDataEndpointConfig).
 
 **Parameters**
 
@@ -242,6 +253,18 @@ type Props = {
 
 ---
 
+### `Actions`
+
+Actions. These do not need to be dispatched.
+
+**Properties**
+
+- `perform` **(`endpointKey` string, `params` [EndpointParams](#endpointparams), `body` any, `instanceId?` string) => [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>** Manually trigger an request to an endpoint. Primarily used for any non-GET requests. For GET requests it is preferred to use [withApiData](#withapidata).
+- `invalidateCache` **(`endpointKey` string, `params` [EndpointParams](#endpointparams), `instanceId?` string) => void** Invalidates the result of a request, settings it's status back to 'ready'. Use for example after a POST, to invalidate
+a GET list request, which might need to include the newly created entity.
+
+---
+
 ### `ApiDataRequest`
 
 Information about a request made to an endpoint.
@@ -329,6 +352,7 @@ Map of parameter names to values.
  Redux' dispatch function. Useful for state related side effects.
 - `getState` **Function**
  Get access to your redux state.
+- `actions` **[Actions](#actions)**
 
 ---
 

--- a/api.md
+++ b/api.md
@@ -248,7 +248,7 @@ Type: **String enum**
 - `perform` **(params?: [EndpointParams](#endpointparams), body?: any) => [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApiDataBinding](#apidatabinding)>**
   Manually trigger a call to the endpoint. The params parameter is merged with the params parameter of the binding. Returns a promise that resolves with an ApiDataBinding after call has completed. Use request networkStatus to see if call was succeeded or not. Both the original ApiDataBinding and the resolved promise contain the result of the performed request.
 - `invalidateCache` **() => Promise&lt;void>** Manually trigger a cache invalidation of the endpoint with the current parameters.
-- `getInstance` **(instanceId: string) => [ApiDataBinding](#apidatabinding)** get an independent instance of this binding. This enables you to make multiple (possibly paralel) calls to the same endpoint while maintaining access to all of them.
+- `getInstance` **(instanceId: string) => [ApiDataBinding](#apidatabinding)** get an independent instance of this binding. This enables you to make multiple (possibly parallel) calls to the same endpoint while maintaining access to all of them.
 
 **Examples**
 

--- a/api.md
+++ b/api.md
@@ -7,12 +7,12 @@
   - [Config](#config)
     - [`configureApiData()`](#configureapidata)
     - [`useRequestHandler()`](#userequesthandler)
-  - [Actions](#actions)
+  - [Redux Actions](#redux-actions)
     - [`afterRehydrate()`](#afterrehydrate)
     - [`performApiRequest()` (Deprecated)](#performapirequest-deprecated)
     - [`invalidateApiDataRequest()` (Deprecated)](#invalidateapidatarequest-deprecated)
   - [Selectors](#selectors)
-    - [getEntity()](#getentity)
+    - [`getEntity()`](#getentity)
     - [`getApiDataRequest()` (Deprecated)](#getapidatarequest-deprecated)
     - [`getResultData()` (Deprecated)](#getresultdata-deprecated)
   - [Types and interfaces](#types-and-interfaces)
@@ -102,7 +102,7 @@ Use your own request function that calls the api and reads the responseBody resp
 - `requestHandler` **RequestHandler**
 
 
-## Actions
+## Redux Actions
 
 ### `afterRehydrate()`
 
@@ -158,7 +158,7 @@ The invalidateApiDataRequest Action has been deprecated. It is recommended to us
 
 ## Selectors
 
-### getEntity()
+### `getEntity()`
 
 Selector for getting a single entity from normalized data.
 
@@ -262,7 +262,7 @@ type Props = {
 
 ### `Actions`
 
-Actions. These do not need to be dispatched.
+Perform actions on any configured endpoint. These actions do not need to be dispatched.
 
 **Properties**
 
@@ -360,6 +360,7 @@ Map of parameter names to values.
 - `getState` **Function**
  Get access to your redux state.
 - `actions` **[Actions](#actions)**
+ Perform actions on any configured endpoint
 
 ---
 

--- a/flow/helpers/getActions.js
+++ b/flow/helpers/getActions.js
@@ -1,0 +1,7 @@
+// @flow
+import { type EndpointParams, type ApiDataBinding } from '..';
+
+export type Actions = {
+    invalidateCache: (endpointKey: string, params?: EndpointParams, instanceId?: string) => void,
+    perform: (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string) => Promise<ApiDataBinding<any>>,
+};

--- a/flow/index.js
+++ b/flow/index.js
@@ -136,7 +136,7 @@ export interface ApiDataConfigAfterProps {
     // redux functions
     dispatch: Function;
     getState: Function;
-    actions: Actions
+    actions: Actions;
 }
 
 /**

--- a/flow/index.js
+++ b/flow/index.js
@@ -1,10 +1,7 @@
 // @flow
 
 import withApiData from './withApiData';
-import reducer, {
-    type Action,
-    type ApiDataState,
-} from './reducer';
+import reducer, { type ApiDataState } from './reducer';
 import { configureApiData } from './actions/configureApiData';
 import { performApiRequest } from './actions/performApiDataRequest';
 import { invalidateApiDataRequest } from './actions/invalidateApiDataRequest';
@@ -14,7 +11,8 @@ import { useRequestHandler } from './actions/performApiDataRequest';
 import { getApiDataRequest } from './selectors/getApiDataRequest';
 import { getResultData } from './selectors/getResultData';
 import { getEntity } from './selectors/getEntity';
-import type { ActionCreator } from 'redux';
+import { type ActionCreator } from 'redux';
+import { type Actions } from './helpers/getActions';
 
 export {
     withApiData,
@@ -138,6 +136,7 @@ export interface ApiDataConfigAfterProps {
     // redux functions
     dispatch: Function;
     getState: Function;
+    actions: Actions
 }
 
 /**

--- a/src/actions/performApiDataRequest.test.ts
+++ b/src/actions/performApiDataRequest.test.ts
@@ -311,6 +311,7 @@ describe('performApiDataRequest', () => {
             resultData: undefined,
             dispatch,
             getState: getStateFn,
+            actions: expect.any(Object),
         };
         expect(endpointAfterSuccess).toHaveBeenCalledWith(afterProps);
         expect(globalAfterSuccess).toHaveBeenCalledWith(afterProps);
@@ -386,6 +387,7 @@ describe('performApiDataRequest', () => {
             resultData: undefined, // result data is not generated in our mock getState function
             dispatch,
             getState: getStateFn,
+            actions: expect.any(Object),
         };
         return expect(afterFailed).toHaveBeenCalledWith(afterProps);
     });

--- a/src/actions/performApiDataRequest.ts
+++ b/src/actions/performApiDataRequest.ts
@@ -20,6 +20,7 @@ import { BindingsStore } from '../helpers/createApiDataBinding';
 import Request, { HandledResponse } from '../request';
 import { cacheExpired } from '../selectors/cacheExpired';
 import { RequestHandler } from '../request';
+import { getActions } from '../helpers/getActions';
 
 export const getRequestProperties = (endpointConfig: ApiDataEndpointConfig, globalConfig: ApiDataGlobalConfig, state: any, body?: any) => {
     const defaultProperties = { body, headers: {}, method: endpointConfig.method };
@@ -145,6 +146,7 @@ export const performApiRequest = (endpointKey: string, params?: EndpointParams, 
                     resultData: getResultData(getState().apiData, endpointKey, params, instanceId),
                     getState,
                     dispatch,
+                    actions: getActions(dispatch),
                 };
             }
 

--- a/src/helpers/getActions.ts
+++ b/src/helpers/getActions.ts
@@ -1,0 +1,16 @@
+import { ActionCreator } from 'redux';
+import { invalidateApiDataRequest, EndpointParams, performApiRequest, ApiDataBinding } from '..';
+
+export type Actions = {
+    invalidateCache: (endpointKey: string, params?: EndpointParams, instanceId?: string) => void,
+    perform: (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string) => Promise<ApiDataBinding<any>>,
+};
+
+export const getActions: (dispatch: ActionCreator<any>) => Actions = (dispatch) => {
+    return {
+        invalidateCache: (endpointKey: string, params?: EndpointParams, instanceId: string = '') => 
+            dispatch(invalidateApiDataRequest(endpointKey, params, instanceId)),
+        perform: (endpointKey: string, params?: EndpointParams, body?: any, instanceId: string = '') => 
+            dispatch(performApiRequest(endpointKey, params, body, instanceId)),
+    };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { getEntity } from './selectors/getEntity';
 import { ActionCreator } from 'redux';
 import reducer from './reducer';
 import { ApiDataState } from './reducer';
+import { Actions } from './helpers/getActions';
 
 export {
     withApiData,
@@ -131,6 +132,7 @@ export interface ApiDataConfigAfterProps {
     // redux functions
     dispatch: Function;
     getState: Function;
+    actions: Actions;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,10 +129,10 @@ export interface ApiDataConfigAfterProps {
     request: ApiDataRequest;
     requestBody?: any;
     resultData: any;
+    actions: Actions;
     // redux functions
     dispatch: Function;
     getState: Function;
-    actions: Actions;
 }
 
 /**

--- a/src/withApiData.tsx
+++ b/src/withApiData.tsx
@@ -8,6 +8,7 @@ import hoistNonReactStatic from 'hoist-non-react-statics';
 import shallowEqual from 'shallowequal';
 import { ThunkDispatch } from 'redux-thunk';
 import { BindingsStore } from './helpers/createApiDataBinding';
+import { getActions, Actions } from './helpers/getActions';
 
 type GetParams<TPropName extends string> = (ownProps: any, state: any) => { [paramName in TPropName]?: EndpointParams | EndpointParams[] };
 
@@ -154,8 +155,9 @@ export default function withApiData<TChildProps extends WithApiDataChildProps<TP
                         addProps[propName] = this.getApiDataBinding(endpointKey, params[propName] as EndpointParams, dispatch, propName, '', apiData);
                     }
                 });
+                const apiDataActions: Actions = getActions(dispatch);
 
-                return <WrappedComponent {...componentProps} {...addProps} />;
+                return <WrappedComponent {...componentProps} {...addProps} apiDataActions={apiDataActions}/>;
             }
         }
 


### PR DESCRIPTION
Remove the need for calling dispatch by:
Bind an extra prop, apiDataActions, with withApiData, which includes the actions:
- perform
- invalidateCache

The functions have dispatch in their closure, so there is no need to dispatch them. Therefore the actioncreators are deprecated.

Also in the endpointconfig:
afterSuccess and afterError get the same Actions object, so these can be used there as well.

The code is written such that getActions could be used by the upcomming hook, useApiDataActions, so this could return the same actions object.