### PR TITLE
Feature/param arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -721,6 +721,14 @@
       "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
       "dev": true
     },
+    "@types/query-string": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.3.0.tgz",
+      "integrity": "sha512-yuIv/WRffRzL7cBW+sla4HwBZrEXRNf1MKQ5SklPEadth+BKbDxiVG8A3iISN5B3yC4EeSCzMZP8llHTcUhOzQ==",
+      "requires": {
+        "query-string": "*"
+      }
+    },
     "@types/react": {
       "version": "16.8.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
@@ -1522,8 +1530,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4892,7 +4899,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4919,7 +4926,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5048,6 +5055,12 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "oberon-prettier-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oberon-prettier-config/-/oberon-prettier-config-1.0.0.tgz",
+      "integrity": "sha512-zVo/pG+v9HYngIPKguWtwd3ckBJcW1YzUKkt9CWPOkZ3X9sIVz1dvD1HUq6OaBMbRladxjb5QzdroTDVTJx9nA==",
       "dev": true
     },
     "object-assign": {
@@ -5337,6 +5350,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -5431,6 +5450,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "query-string": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
+      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "react": {
       "version": "16.12.0",
@@ -6140,6 +6169,11 @@
       "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6204,6 +6238,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,18 +32,20 @@
   },
   "homepage": "https://github.com/oberonamsterdam/react-api-data#readme",
   "devDependencies": {
+    "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^22.2.3",
     "@types/node": "^12.11.7",
+    "@types/react": "^16.8.17",
     "@types/react-redux": "^7.1.5",
     "@types/redux-mock-store": "^1.0.0",
     "@types/shallowequal": "^0.2.3",
-    "@testing-library/react-hooks": "^3.2.1",
-    "@types/react": "^16.8.17",
     "flow-bin": "^0.87.0",
     "flow-copy-source": "^2.0.2",
     "husky": "^1.0.1",
     "jest": "^24.9.0",
     "normalizr": "^3.2.4",
+    "oberon-prettier-config": "^1.0.0",
+    "prettier": "^1.19.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-redux": "7.1.3",
@@ -57,8 +59,10 @@
     "typescript": "^3.7.4"
   },
   "dependencies": {
+    "@types/query-string": "^6.3.0",
     "hoist-non-react-statics": "^3.3.1",
     "normalizr": "^3.2.4",
+    "query-string": "^6.11.1",
     "shallowequal": "^1.0.2"
   },
   "PeerDependencies": {

--- a/src/.prettierrc
+++ b/src/.prettierrc
@@ -1,0 +1,1 @@
+"oberon-prettier-config"

--- a/src/actions/performApiDataRequest.ts
+++ b/src/actions/performApiDataRequest.ts
@@ -1,11 +1,11 @@
 import { ApiDataState } from '../reducer';
 import {
-    ApiDataBinding, 
-    ApiDataConfigAfterProps, 
+    ApiDataBinding,
+    ApiDataConfigAfterProps,
     ApiDataConfigBeforeProps,
     ApiDataEndpointConfig,
     ApiDataGlobalConfig,
-    EndpointParams, 
+    EndpointParams,
     ApiDataRequest
 } from '../types';
 import { getApiDataRequest } from '../selectors/getApiDataRequest';
@@ -51,7 +51,7 @@ let requestFunction = Request;
 
 const __DEV__ = process.env.NODE_ENV === 'development';
 
-type PerformApiRequest = (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string, bindingsStore?: BindingsStore) => 
+type PerformApiRequest = (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string, bindingsStore?: BindingsStore) =>
     (dispatch: Dispatch, getState: () => { apiData: ApiDataState }) => Promise<ApiDataBinding<any>>;
 
 /**
@@ -85,7 +85,7 @@ export const performApiRequest: PerformApiRequest = (endpointKey: string, params
         }
 
         const requestKey = getRequestKey(endpointKey, params || {}, instanceId);
-        const url = formatUrl(config.url, params);
+        const url = formatUrl(config.url, params, config.queryStringOpts);
 
         dispatch(({
             type: 'FETCH_API_DATA',

--- a/src/helpers/formatUrl.test.ts
+++ b/src/helpers/formatUrl.test.ts
@@ -21,7 +21,7 @@ describe('formatUrl', () => {
     });
 
     it('should handle arrays correctly', () => {
-        expect(formatUrl('https://test.com/', { ids: ['1', '2'] })).toBe('https://test.com/?ids[]=1&ids[]=2');
-        expect(() => formatUrl('https://test.com/:ids', { ids: ['1', '2'] })).toThrow(TypeError);
+        expect(formatUrl('https://test.com/', { ids: [1, 2] })).toBe('https://test.com/?ids[]=1&ids[]=2');
+        expect(() => formatUrl('https://test.com/:ids', { ids: [1, 2] })).toThrow(TypeError);
     });
 });

--- a/src/helpers/formatUrl.test.ts
+++ b/src/helpers/formatUrl.test.ts
@@ -1,17 +1,27 @@
-import {formatUrl} from './formatUrl';
+import { formatUrl } from './formatUrl';
 
 describe('formatUrl', () => {
     it('should inject params when specified in URL and add remaining params to querystring', () => {
         expect(formatUrl('https://test.com/:category/:id', {})).toBe('https://test.com//');
-        expect(formatUrl('https://test.com/:category/:id', {category: 1, id: 2})).toBe('https://test.com/1/2');
-        expect(formatUrl('https://test.com/:category/:id', {category: 1, id: 2, filter: 'abc'})).toBe('https://test.com/1/2?filter=abc');
-        expect(formatUrl('https://test.com/?fixed=x', {q: 'abc'})).toBe('https://test.com/?fixed=x&q=abc');
-        expect(formatUrl('https://test.com/', {q: 'abc'})).toBe('https://test.com/?q=abc');
+        expect(formatUrl('https://test.com/:category/:id', { category: 1, id: 2 })).toBe('https://test.com/1/2');
+        expect(formatUrl('https://test.com/:category/:id', { category: 1, id: 2, filter: 'abc' })).toBe(
+            'https://test.com/1/2?filter=abc'
+        );
+        expect(formatUrl('https://test.com/?fixed=x', { q: 'abc' })).toBe('https://test.com/?fixed=x&q=abc');
+        expect(formatUrl('https://test.com/', { q: 'abc' })).toBe('https://test.com/?q=abc');
     });
 
     it('should encode special chars in params', () => {
-        expect(formatUrl('https://www.test.com/?:keyword', {keyword: 'search keyword'})).toBe('https://www.test.com/?search%20keyword');
-        expect(formatUrl('https://www.test.com/', {keyword: 'search keyword'})).toBe('https://www.test.com/?keyword=search%20keyword');
+        expect(formatUrl('https://www.test.com/?:keyword', { keyword: 'search keyword' })).toBe(
+            'https://www.test.com/?search%20keyword'
+        );
+        expect(formatUrl('https://www.test.com/', { keyword: 'search keyword' })).toBe(
+            'https://www.test.com/?keyword=search%20keyword'
+        );
     });
 
+    it('should handle arrays correctly', () => {
+        expect(formatUrl('https://test.com/', { ids: ['1', '2'] })).toBe('https://test.com/?ids[]=1&ids[]=2');
+        expect(() => formatUrl('https://test.com/:ids', { ids: ['1', '2'] })).toThrow(TypeError);
+    });
 });

--- a/src/helpers/formatUrl.ts
+++ b/src/helpers/formatUrl.ts
@@ -5,7 +5,7 @@ export const formatUrl = (url: string, params?: EndpointParams, queryStringOpts?
     if (!params) {
         return url;
     }
-    // const {query: existingParams} = parseUrl(url);
+
     const replacedParams = new Set();
     const parsedUrl = url.replace(/:[a-zA-Z]+/g, match => {
         const paramName = match.substr(1);

--- a/src/helpers/formatUrl.ts
+++ b/src/helpers/formatUrl.ts
@@ -1,30 +1,42 @@
 import { EndpointParams } from '../types';
+import { stringifyUrl, StringifyOptions } from 'query-string';
 
-export const formatUrl = (url: string, params?: EndpointParams): string => {
+export const formatUrl = (url: string, params?: EndpointParams, queryStringOpts?: StringifyOptions): string => {
     if (!params) {
         return url;
     }
+    // const {query: existingParams} = parseUrl(url);
     const replacedParams = new Set();
-    let result = url.replace(
-        /:[a-zA-Z]+/g,
-        match => {
-            const paramName = match.substr(1);
-            if (params[paramName]) {
-                replacedParams.add(paramName);
-                return encodeURIComponent(String(params[paramName]));
+    const parsedUrl = url.replace(/:[a-zA-Z]+/g, match => {
+        const paramName = match.substr(1);
+        if (params[paramName]) {
+            if (Array.isArray(params[paramName])) {
+                throw new TypeError(
+                    'react-api-data: tried to use an array in an url parameter, this is supported, but only with query parameters.\nEither remove the parameter from your url, or change the type.'
+                );
             }
-            return '';
+
+            replacedParams.add(paramName);
+            return encodeURIComponent(String(params[paramName]));
         }
+        return '';
+    });
+
+    const query = Object.assign(
+        {},
+        ...Object.entries(params)
+            .filter(([paramName]) => !replacedParams.has(paramName))
+            .map(([key, val]) => ({ [key]: val }))
     );
 
-    const queryString = Object.keys(params)
-        .filter(paramName => !replacedParams.has(paramName))
-        .map(paramName => `${paramName}=${encodeURIComponent(String(params[paramName]))}`)
-        .join('&');
-
-    if (queryString) {
-        result += url.includes('?') ? '&' : '?';
-    }
-
-    return result + queryString;
+    return stringifyUrl(
+        {
+            url: parsedUrl,
+            query,
+        },
+        {
+            arrayFormat: 'bracket',
+            ...queryStringOpts,
+        }
+    );
 };

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -25,7 +25,12 @@
  * THIS STORE ITSELF IS CONSIDERED PRIVATE TO THIS LIB AND IT'S ARCHITECTURE MIGHT CHANGE. An interface is provided through
  * the HOC and the selectors, use those.
  */
-import { ApiDataEndpointConfig, ApiDataGlobalConfig, ApiDataRequest, EndpointParams, NetworkStatus } from './types';
+import {
+    ApiDataEndpointConfig,
+    ApiDataGlobalConfig,
+    ApiDataRequest, EndpointParams,
+    NetworkStatus,
+} from './types';
 import { ConfigureApiDataAction } from './actions/configureApiData';
 import { ApiDataSuccessAction } from './actions/apiDataSuccess';
 import { ApiDataFailAction } from './actions/apiDataFail';
@@ -38,17 +43,17 @@ import { PurgeRequestAction } from './actions/purgeRequest';
 
 interface Entities {
     [type: string]: {
-        [id: string]: any;
+        [id: string]: any
     };
 }
 
 export interface ApiDataState {
     globalConfig: ApiDataGlobalConfig;
     endpointConfig: {
-        [endpointKey: string]: ApiDataEndpointConfig;
+        [endpointKey: string]: ApiDataEndpointConfig
     };
     requests: {
-        [requestKey: string]: ApiDataRequest;
+        [requestKey: string]: ApiDataRequest
     };
     entities: Entities;
 }
@@ -57,7 +62,7 @@ export const defaultState = {
     globalConfig: {},
     endpointConfig: {},
     requests: {},
-    entities: {},
+    entities: {}
 };
 
 export interface ClearApiDataAction {
@@ -67,10 +72,10 @@ export interface ClearApiDataAction {
 export interface FetchApiDataAction {
     type: 'FETCH_API_DATA';
     payload: {
-        requestKey: string;
-        endpointKey: string;
-        params?: EndpointParams;
-        url: string;
+        requestKey: string,
+        endpointKey: string,
+        params?: EndpointParams,
+        url: string,
     };
 }
 
@@ -83,7 +88,8 @@ export type Action =
     | ClearApiDataAction
     | ApiDataAfterRehydrateAction
     | PurgeRequestAction
-    | PurgeAllApiDataAction;
+    | PurgeAllApiDataAction
+    ;
 
 // reducer
 
@@ -92,7 +98,7 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
         case 'CONFIGURE_API_DATA':
             return {
                 ...state,
-                ...action.payload,
+                ...action.payload
             };
         case 'FETCH_API_DATA':
             return {
@@ -107,8 +113,8 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         endpointKey: action.payload.endpointKey,
                         params: action.payload.params,
                         url: action.payload.url,
-                    },
-                },
+                    }
+                }
             };
         case 'API_DATA_SUCCESS': {
             const request = state.requests[action.payload.requestKey];
@@ -125,18 +131,17 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         ...request,
                         networkStatus: 'success',
                         duration: Date.now() - request.lastCall,
-                        result: action.payload.normalizedData
-                            ? action.payload.normalizedData.result
-                            : action.payload.responseBody,
+                        result: action.payload.normalizedData ? action.payload.normalizedData.result : action.payload.responseBody,
                         response: action.payload.response,
-                        errorBody: undefined,
-                    },
+                        errorBody: undefined
+                    }
                 },
                 entities: {
                     ...(action.payload.normalizedData
-                        ? addEntities(state.entities, action.payload.normalizedData.entities)
-                        : state.entities),
-                },
+                            ? addEntities(state.entities, action.payload.normalizedData.entities)
+                            : state.entities
+                    )
+                }
             };
         }
         case 'API_DATA_FAIL': {
@@ -156,35 +161,31 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         duration: Date.now() - request.lastCall,
                         response: action.payload.response,
                         errorBody: action.payload.errorBody,
-                        result: undefined,
-                    },
-                },
+                        result: undefined
+                    }
+                }
             };
         }
         case 'INVALIDATE_API_DATA_REQUEST': {
             const request = state.requests[action.payload.requestKey];
-            return request
-                ? {
-                    ...state,
-                    requests: {
-                        ...state.requests,
-                        [action.payload.requestKey]: {
-                            ...request,
-                            networkStatus: 'ready',
-                        },
-                    },
+            return request ? {
+                ...state,
+                requests: {
+                    ...state.requests,
+                    [action.payload.requestKey]: {
+                        ...request,
+                        networkStatus: 'ready'
+                    }
                 }
-                : state;
+            } : state;
         }
         case 'PURGE_API_DATA_REQUEST': {
             const requests = { ...state.requests };
             delete requests[action.payload.requestKey];
-            return requests
-                ? {
-                    ...state,
-                    requests,
-                }
-                : state;
+            return requests ? {
+                ...state,
+                requests
+            } : state;
         }
         case 'CLEAR_API_DATA': {
             return defaultState;
@@ -199,7 +200,7 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
         case 'API_DATA_AFTER_REHYDRATE':
             return {
                 ...state,
-                requests: recoverNetworkStatuses(state.requests),
+                requests: recoverNetworkStatuses(state.requests)
             };
         default:
             return state;
@@ -207,34 +208,31 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
 };
 
 // merges newEntities into entities
-export const addEntities = (entities: Entities, newEntities: Entities): Entities =>
-    Object.keys(newEntities).reduce(
-        (result, entityType) => ({
-            ...result,
-            [entityType]: {
-                ...(entities[entityType] || {}),
-                ...newEntities[entityType],
-            },
-        }),
-        { ...entities }
-    );
+export const addEntities = (entities: Entities, newEntities: Entities): Entities => Object.keys(newEntities).reduce(
+    (result, entityType) => ({
+        ...result,
+        [entityType]: {
+            ...(entities[entityType] || {}),
+            ...newEntities[entityType]
+        }
+    }),
+    { ...entities }
+);
 
 // resets a networkStatus to ready if it was loading. Use when recovering state from storage to prevent loading states
 // when no calls are running.
 export const recoverNetworkStatus = (networkStatus: NetworkStatus): NetworkStatus =>
     networkStatus === 'loading' ? 'ready' : networkStatus;
 
-export const recoverNetworkStatuses = (requests: {
-    [requestKey: string]: ApiDataRequest;
-}): { [requestKey: string]: ApiDataRequest } => ({
-    ...Object.keys(requests).reduce(
-        (result, key) => ({
-            ...result,
-            [key]: {
-                ...requests[key],
-                networkStatus: recoverNetworkStatus(requests[key].networkStatus),
-            },
-        }),
-        {}
-    ),
+export const recoverNetworkStatuses = (requests: { [requestKey: string]: ApiDataRequest }): { [requestKey: string]: ApiDataRequest } => ({
+    ...(Object.keys(requests).reduce(
+            (result, key) => ({
+                ...result,
+                [key]: {
+                    ...requests[key],
+                    networkStatus: recoverNetworkStatus(requests[key].networkStatus)
+                }
+            }),
+            {})
+    )
 });

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -25,12 +25,7 @@
  * THIS STORE ITSELF IS CONSIDERED PRIVATE TO THIS LIB AND IT'S ARCHITECTURE MIGHT CHANGE. An interface is provided through
  * the HOC and the selectors, use those.
  */
-import {
-    ApiDataEndpointConfig,
-    ApiDataGlobalConfig,
-    ApiDataRequest, EndpointParams,
-    NetworkStatus,
-} from './types';
+import { ApiDataEndpointConfig, ApiDataGlobalConfig, ApiDataRequest, EndpointParams, NetworkStatus } from './types';
 import { ConfigureApiDataAction } from './actions/configureApiData';
 import { ApiDataSuccessAction } from './actions/apiDataSuccess';
 import { ApiDataFailAction } from './actions/apiDataFail';
@@ -43,17 +38,17 @@ import { PurgeRequestAction } from './actions/purgeRequest';
 
 interface Entities {
     [type: string]: {
-        [id: string]: any
+        [id: string]: any;
     };
 }
 
 export interface ApiDataState {
     globalConfig: ApiDataGlobalConfig;
     endpointConfig: {
-        [endpointKey: string]: ApiDataEndpointConfig
+        [endpointKey: string]: ApiDataEndpointConfig;
     };
     requests: {
-        [requestKey: string]: ApiDataRequest
+        [requestKey: string]: ApiDataRequest;
     };
     entities: Entities;
 }
@@ -62,7 +57,7 @@ export const defaultState = {
     globalConfig: {},
     endpointConfig: {},
     requests: {},
-    entities: {}
+    entities: {},
 };
 
 export interface ClearApiDataAction {
@@ -72,10 +67,10 @@ export interface ClearApiDataAction {
 export interface FetchApiDataAction {
     type: 'FETCH_API_DATA';
     payload: {
-        requestKey: string,
-        endpointKey: string,
-        params?: EndpointParams,
-        url: string,
+        requestKey: string;
+        endpointKey: string;
+        params?: EndpointParams;
+        url: string;
     };
 }
 
@@ -88,8 +83,7 @@ export type Action =
     | ClearApiDataAction
     | ApiDataAfterRehydrateAction
     | PurgeRequestAction
-    | PurgeAllApiDataAction
-    ;
+    | PurgeAllApiDataAction;
 
 // reducer
 
@@ -98,7 +92,7 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
         case 'CONFIGURE_API_DATA':
             return {
                 ...state,
-                ...action.payload
+                ...action.payload,
             };
         case 'FETCH_API_DATA':
             return {
@@ -113,8 +107,8 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         endpointKey: action.payload.endpointKey,
                         params: action.payload.params,
                         url: action.payload.url,
-                    }
-                }
+                    },
+                },
             };
         case 'API_DATA_SUCCESS': {
             const request = state.requests[action.payload.requestKey];
@@ -131,17 +125,18 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         ...request,
                         networkStatus: 'success',
                         duration: Date.now() - request.lastCall,
-                        result: action.payload.normalizedData ? action.payload.normalizedData.result : action.payload.responseBody,
+                        result: action.payload.normalizedData
+                            ? action.payload.normalizedData.result
+                            : action.payload.responseBody,
                         response: action.payload.response,
-                        errorBody: undefined
-                    }
+                        errorBody: undefined,
+                    },
                 },
                 entities: {
                     ...(action.payload.normalizedData
-                            ? addEntities(state.entities, action.payload.normalizedData.entities)
-                            : state.entities
-                    )
-                }
+                        ? addEntities(state.entities, action.payload.normalizedData.entities)
+                        : state.entities),
+                },
             };
         }
         case 'API_DATA_FAIL': {
@@ -161,31 +156,35 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
                         duration: Date.now() - request.lastCall,
                         response: action.payload.response,
                         errorBody: action.payload.errorBody,
-                        result: undefined
-                    }
-                }
+                        result: undefined,
+                    },
+                },
             };
         }
         case 'INVALIDATE_API_DATA_REQUEST': {
             const request = state.requests[action.payload.requestKey];
-            return request ? {
-                ...state,
-                requests: {
-                    ...state.requests,
-                    [action.payload.requestKey]: {
-                        ...request,
-                        networkStatus: 'ready'
-                    }
+            return request
+                ? {
+                    ...state,
+                    requests: {
+                        ...state.requests,
+                        [action.payload.requestKey]: {
+                            ...request,
+                            networkStatus: 'ready',
+                        },
+                    },
                 }
-            } : state;
+                : state;
         }
         case 'PURGE_API_DATA_REQUEST': {
             const requests = { ...state.requests };
             delete requests[action.payload.requestKey];
-            return requests ? {
-                ...state,
-                requests
-            } : state;
+            return requests
+                ? {
+                    ...state,
+                    requests,
+                }
+                : state;
         }
         case 'CLEAR_API_DATA': {
             return defaultState;
@@ -200,7 +199,7 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
         case 'API_DATA_AFTER_REHYDRATE':
             return {
                 ...state,
-                requests: recoverNetworkStatuses(state.requests)
+                requests: recoverNetworkStatuses(state.requests),
             };
         default:
             return state;
@@ -208,31 +207,34 @@ export default (state: ApiDataState = defaultState, action: Action): ApiDataStat
 };
 
 // merges newEntities into entities
-export const addEntities = (entities: Entities, newEntities: Entities): Entities => Object.keys(newEntities).reduce(
-    (result, entityType) => ({
-        ...result,
-        [entityType]: {
-            ...(entities[entityType] || {}),
-            ...newEntities[entityType]
-        }
-    }),
-    { ...entities }
-);
+export const addEntities = (entities: Entities, newEntities: Entities): Entities =>
+    Object.keys(newEntities).reduce(
+        (result, entityType) => ({
+            ...result,
+            [entityType]: {
+                ...(entities[entityType] || {}),
+                ...newEntities[entityType],
+            },
+        }),
+        { ...entities }
+    );
 
 // resets a networkStatus to ready if it was loading. Use when recovering state from storage to prevent loading states
 // when no calls are running.
 export const recoverNetworkStatus = (networkStatus: NetworkStatus): NetworkStatus =>
     networkStatus === 'loading' ? 'ready' : networkStatus;
 
-export const recoverNetworkStatuses = (requests: { [requestKey: string]: ApiDataRequest }): { [requestKey: string]: ApiDataRequest } => ({
-    ...(Object.keys(requests).reduce(
-            (result, key) => ({
-                ...result,
-                [key]: {
-                    ...requests[key],
-                    networkStatus: recoverNetworkStatus(requests[key].networkStatus)
-                }
-            }),
-            {})
-    )
+export const recoverNetworkStatuses = (requests: {
+    [requestKey: string]: ApiDataRequest;
+}): { [requestKey: string]: ApiDataRequest } => ({
+    ...Object.keys(requests).reduce(
+        (result, key) => ({
+            ...result,
+            [key]: {
+                ...requests[key],
+                networkStatus: recoverNetworkStatus(requests[key].networkStatus),
+            },
+        }),
+        {}
+    ),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ export type NormalizeResult = string | number | Array<string | number>;
 export interface NormalizedData {
     entities: {
         [type: string]: {
-            [id: string]: any;
-        };
+            [id: string]: any,
+        }
     };
     result: NormalizeResult;
 }
@@ -20,7 +20,7 @@ export interface NormalizedData {
  * Map parameter names to values.
  */
 export interface EndpointParams {
-    [paramName: string]: string | number | string[];
+    [paramName: string]: string | number | string[] | number[];
 }
 
 /**
@@ -41,15 +41,9 @@ export interface ApiDataRequest {
 export interface ApiDataGlobalConfig {
     setHeaders?: (defaultHeaders: any, state: any) => any;
     setRequestProperties?: (defaultProperties: object, state: object) => object;
-    beforeSuccess?: (
-        handledResponse: { response: Response; body: any },
-        beforeProps: ApiDataConfigBeforeProps
-    ) => { response: Response; body: any };
+    beforeSuccess?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
     afterSuccess?: (afterProps: ApiDataConfigAfterProps) => void;
-    beforeFailed?: (
-        handledResponse: { response: Response; body: any },
-        beforeProps: ApiDataConfigBeforeProps
-    ) => { response: Response; body: any };
+    beforeFailed?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
     afterFailed?: (afterProps: ApiDataConfigAfterProps) => void;
     timeout?: number;
     autoTrigger?: boolean;
@@ -67,49 +61,36 @@ export interface ApiDataEndpointConfig {
     responseSchema?: any;
     queryStringOpts?: StringifyOptions;
     /*
-     * @deprecated Use beforeSuccess instead
-     */
+    * @deprecated Use beforeSuccess instead
+    */
     transformResponseBody?: (responseBody: any) => NormalizedData; // todo: this should transform before normalize or without normalize if no schema (so return any)
     /*
-     * @deprecated Use beforeFailed instead
-     */
-    handleErrorResponse?: (
-        responseBody: any,
-        params: EndpointParams,
-        requestBody: any,
-        dispatch: ActionCreator<any>,
-        getState: () => { apiData: ApiDataState },
-        response?: Response
-    ) => boolean | void;
+    * @deprecated Use beforeFailed instead
+    */
+    handleErrorResponse?: (responseBody: any, params: EndpointParams, requestBody: any, dispatch: ActionCreator<any>, getState: () => { apiData: ApiDataState }, response?: Response) => boolean | void;
     /*
-     * Edit the response before it gets handled by react-api-data.
-     */
-    beforeFailed?: (
-        handledResponse: { response: Response; body: any },
-        beforeProps: ApiDataConfigBeforeProps
-    ) => { response: Response; body: any };
+    * Edit the response before it gets handled by react-api-data.
+    */
+    beforeFailed?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
     /*
-     * return false to not trigger global function
-     */
+    * return false to not trigger global function
+    */
     afterFailed?: (afterProps: ApiDataConfigAfterProps) => boolean | void;
     /*
-     * Edit the response before it gets handled by react-api-data. Set response.ok to false to turn the success into a fail.
-     */
-    beforeSuccess?: (
-        handledResponse: { response: Response; body: any },
-        beforeProps: ApiDataConfigBeforeProps
-    ) => { response: Response; body: any };
+    * Edit the response before it gets handled by react-api-data. Set response.ok to false to turn the success into a fail.
+    */
+    beforeSuccess?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
     /*
-     * return false to not trigger global function
-     */
+    * return false to not trigger global function
+    */
     afterSuccess?: (afterProps: ApiDataConfigAfterProps) => boolean | void;
     /*
-     * defaultHeaders will be the headers returned by the setHeaders function from the global config, if set
-     */
+    * defaultHeaders will be the headers returned by the setHeaders function from the global config, if set
+    */
     setHeaders?: (defaultHeaders: object, state: object) => object;
     /*
-     * defaultPropertie will be the properties returned by the setRequestproperties function from the global config, if set
-     */
+    * defaultPropertie will be the properties returned by the setRequestproperties function from the global config, if set
+    */
     setRequestProperties?: (defaultProperties: object, state: object) => object;
 
     timeout?: number;
@@ -150,12 +131,6 @@ export interface ApiDataBinding<T> {
 
 export interface Actions {
     invalidateCache: (endpointKey: string, params?: EndpointParams, instanceId?: string) => void;
-    perform: (
-        endpointKey: string,
-        params?: EndpointParams,
-        body?: any,
-        instanceId?: string,
-        bindingsStore?: BindingsStore
-    ) => Promise<ApiDataBinding<any>>;
+    perform: (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string, bindingsStore?: BindingsStore) => Promise<ApiDataBinding<any>>;
     purgeAll: () => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { ActionCreator, Dispatch } from 'redux';
 import { ApiDataState } from './reducer';
 import { BindingsStore } from './helpers/createApiDataBinding';
+import { StringifyOptions } from 'query-string';
 
 export type NetworkStatus = 'ready' | 'loading' | 'failed' | 'success';
 
@@ -9,8 +10,8 @@ export type NormalizeResult = string | number | Array<string | number>;
 export interface NormalizedData {
     entities: {
         [type: string]: {
-            [id: string]: any,
-        }
+            [id: string]: any;
+        };
     };
     result: NormalizeResult;
 }
@@ -19,7 +20,7 @@ export interface NormalizedData {
  * Map parameter names to values.
  */
 export interface EndpointParams {
-    [paramName: string]: string | number;
+    [paramName: string]: string | number | string[];
 }
 
 /**
@@ -40,9 +41,15 @@ export interface ApiDataRequest {
 export interface ApiDataGlobalConfig {
     setHeaders?: (defaultHeaders: any, state: any) => any;
     setRequestProperties?: (defaultProperties: object, state: object) => object;
-    beforeSuccess?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
+    beforeSuccess?: (
+        handledResponse: { response: Response; body: any },
+        beforeProps: ApiDataConfigBeforeProps
+    ) => { response: Response; body: any };
     afterSuccess?: (afterProps: ApiDataConfigAfterProps) => void;
-    beforeFailed?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
+    beforeFailed?: (
+        handledResponse: { response: Response; body: any },
+        beforeProps: ApiDataConfigBeforeProps
+    ) => { response: Response; body: any };
     afterFailed?: (afterProps: ApiDataConfigAfterProps) => void;
     timeout?: number;
     autoTrigger?: boolean;
@@ -57,38 +64,52 @@ export interface ApiDataEndpointConfig {
     url: string; // add parameters as :paramName, eg https://myapi.org/:myparam
     method: Method;
     cacheDuration?: number;
-    responseSchema?: any | any[];
+    responseSchema?: any;
+    queryStringOpts?: StringifyOptions;
     /*
-    * @deprecated Use beforeSuccess instead
-    */
+     * @deprecated Use beforeSuccess instead
+     */
     transformResponseBody?: (responseBody: any) => NormalizedData; // todo: this should transform before normalize or without normalize if no schema (so return any)
     /*
-    * @deprecated Use beforeFailed instead
-    */
-    handleErrorResponse?: (responseBody: any, params: EndpointParams, requestBody: any, dispatch: ActionCreator<any>, getState: () => { apiData: ApiDataState }, response?: Response) => boolean | void;
+     * @deprecated Use beforeFailed instead
+     */
+    handleErrorResponse?: (
+        responseBody: any,
+        params: EndpointParams,
+        requestBody: any,
+        dispatch: ActionCreator<any>,
+        getState: () => { apiData: ApiDataState },
+        response?: Response
+    ) => boolean | void;
     /*
-    * Edit the response before it gets handled by react-api-data.
-    */
-    beforeFailed?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
+     * Edit the response before it gets handled by react-api-data.
+     */
+    beforeFailed?: (
+        handledResponse: { response: Response; body: any },
+        beforeProps: ApiDataConfigBeforeProps
+    ) => { response: Response; body: any };
     /*
-    * return false to not trigger global function
-    */
+     * return false to not trigger global function
+     */
     afterFailed?: (afterProps: ApiDataConfigAfterProps) => boolean | void;
     /*
-    * Edit the response before it gets handled by react-api-data. Set response.ok to false to turn the success into a fail.
-    */
-    beforeSuccess?: (handledResponse: { response: Response, body: any }, beforeProps: ApiDataConfigBeforeProps) => { response: Response, body: any };
+     * Edit the response before it gets handled by react-api-data. Set response.ok to false to turn the success into a fail.
+     */
+    beforeSuccess?: (
+        handledResponse: { response: Response; body: any },
+        beforeProps: ApiDataConfigBeforeProps
+    ) => { response: Response; body: any };
     /*
-    * return false to not trigger global function
-    */
+     * return false to not trigger global function
+     */
     afterSuccess?: (afterProps: ApiDataConfigAfterProps) => boolean | void;
     /*
-    * defaultHeaders will be the headers returned by the setHeaders function from the global config, if set
-    */
+     * defaultHeaders will be the headers returned by the setHeaders function from the global config, if set
+     */
     setHeaders?: (defaultHeaders: object, state: object) => object;
     /*
-    * defaultPropertie will be the properties returned by the setRequestproperties function from the global config, if set
-    */
+     * defaultPropertie will be the properties returned by the setRequestproperties function from the global config, if set
+     */
     setRequestProperties?: (defaultProperties: object, state: object) => object;
 
     timeout?: number;
@@ -129,6 +150,12 @@ export interface ApiDataBinding<T> {
 
 export interface Actions {
     invalidateCache: (endpointKey: string, params?: EndpointParams, instanceId?: string) => void;
-    perform: (endpointKey: string, params?: EndpointParams, body?: any, instanceId?: string, bindingsStore?: BindingsStore) => Promise<ApiDataBinding<any>>;
+    perform: (
+        endpointKey: string,
+        params?: EndpointParams,
+        body?: any,
+        instanceId?: string,
+        bindingsStore?: BindingsStore
+    ) => Promise<ApiDataBinding<any>>;
     purgeAll: () => void;
 }


### PR DESCRIPTION
- Arrays kunnen nu meegeven worden als value in een EndpointParams
- Standaard word bracket notatie gebruikt (`ids[]=1` ipv `ids=1`), maar dit is te overschrijven vanuit `perform()`
- Dit werkt alleen voor query string params, niet voor uri params. In dit geval throwen we een error.
- Onze eigen query stringifier is vervangen met `query-string` ([1.8kb gzipped](https://bundlephobia.com/result?p=query-string@6.11.1))
- Tests geschreven voor de volgende situaties:
   - Een array word meegegeven voor een uri parameter = crash
   - Een array word meegeven voor een query parameter zorgt voor het juiste formaat (`&ids[]=2`)